### PR TITLE
Only generate hash when tracing.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -69,9 +69,12 @@ class RequestHandler {
     private AtomicInteger executionCount = new AtomicInteger();
 
     public RequestHandler(SessionManager manager, Callback callback, Statement statement) {
-        this.id = Long.toString(System.identityHashCode(this));
-        if(logger.isTraceEnabled())
+        if(logger.isTraceEnabled()) {
+            this.id = Long.toString(System.identityHashCode(this));
             logger.trace("[{}] {}", id, statement);
+        } else {
+            this.id = "unknown";
+        }
         this.manager = manager;
         this.callback = callback;
         this.scheduler = manager.cluster.manager.connectionFactory.timer;


### PR DESCRIPTION
This showed up in a profiling dump as expensive. Seems like it may only be required when tracing, so moved to block.
